### PR TITLE
Included changes to store dropped particles as MCParticleLite

### DIFF
--- a/larg4/Core/CMakeLists.txt
+++ b/larg4/Core/CMakeLists.txt
@@ -1,5 +1,6 @@
 cet_build_plugin(larg4Main art::EDProducer
   LIBRARIES PRIVATE
+  lardataobj::MCBase
   larg4::pluginActions_MCTruthEventAction_service
   larg4::pluginActions_ParticleListAction_service
   lardataalg::MCDumpers
@@ -21,6 +22,7 @@ cet_build_plugin(larg4Main art::EDProducer
 
 cet_build_plugin(larg4SingleGen art::EDProducer
   LIBRARIES PRIVATE
+  lardataobj::MCBase
   nusimdata::SimulationBase
   nurandom::RandomUtils_NuRandomService_service
   art::Framework_Services_Registry

--- a/larg4/Core/larg4SingleGen_module.cc
+++ b/larg4/Core/larg4SingleGen_module.cc
@@ -36,6 +36,7 @@
 #include "nurandom/RandomUtils/NuRandomService.h"
 
 //  nusimdata includes
+#include "lardataobj/MCBase/MCParticleLite.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
 

--- a/larg4/pluginActions/ParticleListAction_service.h
+++ b/larg4/pluginActions/ParticleListAction_service.h
@@ -17,6 +17,7 @@
 
 #include "lardataobj/Simulation/GeneratedParticleInfo.h"
 #include "lardataobj/Simulation/ParticleAncestryMap.h"
+#include "lardataobj/MCBase/MCParticleLite.h"
 
 #include "artg4tk/actionBase/EventActionBase.hh"
 #include "artg4tk/actionBase/SteppingActionBase.hh"
@@ -100,6 +101,10 @@ namespace larg4 {
     {
       return std::move(partCol_);
     }
+    std::unique_ptr<std::vector<sim::MCParticleLite>> DroppedParticleCollection()
+    {
+      return std::move(droppedPartCol_);
+    }
     std::unique_ptr<sim::ParticleAncestryMap> DroppedTracksCollection()
     {
       return std::move(droppedCol_);
@@ -140,8 +145,14 @@ namespace larg4 {
 
     }; // ParticleInfo_t
 
+    // Returns whether the particle was dropped
+    bool isDropped(simb::MCParticle const* p);
+
     // Yields the ParticleList accumulated during the current event.
     sim::ParticleList&& YieldList();
+
+    // Yields the (dropped) ParticleList accumulated during the current event.
+    sim::ParticleList&& YieldDroppedList();
 
     // this method will loop over the fParentIDMap to get the
     // parentage of the provided trackid
@@ -175,6 +186,9 @@ namespace larg4 {
     double fSparsifyMargin;        ///< set the sparsification margin
     bool fKeepTransportation;      ///< tell whether or not to keep the transportation process
     bool fKeepSecondToLast; ///< tell whether or not to force keeping the second to last point
+    bool fStoreDroppedMCParticles; ///< Whether to keep a `sim::MCParticleLite` list of dropped particles
+    std::unique_ptr<sim::ParticleList> fdroppedParticleList;   ///< The accumulated particle information for
+                                      ///< all (dropped) particles in the event.
 
     std::vector<art::Handle<std::vector<simb::MCTruth>>> const*
       fMCLists; ///< MCTruthCollection input lists
@@ -198,6 +212,8 @@ namespace larg4 {
     std::map<int, std::set<int>> fdroppedTracksMap;
 
     std::unique_ptr<std::vector<simb::MCParticle>> partCol_;
+    /// This collection will hold the MCParticleLite objects created from dropped particles
+    std::unique_ptr<std::vector<sim::MCParticleLite>> droppedPartCol_;
     std::unique_ptr<sim::ParticleAncestryMap> droppedCol_;
     std::unique_ptr<art::Assns<simb::MCTruth, simb::MCParticle, sim::GeneratedParticleInfo>>
       tpassn_;


### PR DESCRIPTION
Added option to store dropped particles, mainly em showers, as MCParticleLite. This is used in the ML reco chain and was previously implemented in legacy larg4 [here](https://github.com/SBNSoftware/larsim/blob/3aee447758f8d0e70152fbd0b4cfe48c0bddde60/larsim/LegacyLArG4/LArG4_module.cc#L411C6-L411C6). 

Tests have been made to ensure the  behavior is correct when keep em shower daughters is off/on or keep dropped particles is off/on in the gpvms.